### PR TITLE
Fix redundant square bracket escape in regex

### DIFF
--- a/src/components/wiki.ts
+++ b/src/components/wiki.ts
@@ -36,9 +36,9 @@ enum parse_state {
     done,
 }
 
-const image_regex = /!\[[^\]]*\]\(([^)]*)\)/;
-const reference_definition_regex = /\s*\[([^\]]*)\]: (.+)/;
-const reference_link_regex = /\[([^\]]*)\]\[([^\]]*)\]/g;
+const image_regex = /!\[[^\]]*]\(([^)]*)\)/;
+const reference_definition_regex = /\s*\[([^\]]*)]: (.+)/;
+const reference_link_regex = /\[([^\]]*)]\[([^\]]*)]/g;
 
 /**
  * One-time use class for parsing articles.


### PR DESCRIPTION
This was giving me IDE warnings. Also IIRC there are ESLint rules that detect this. Better for code quality to have it fixed.