### PR TITLE
Change recommendations for C

### DIFF
--- a/wiki_articles/pi.md
+++ b/wiki_articles/pi.md
@@ -9,15 +9,17 @@ constexpr T      pi = std::numbers::pi_v<T>;
 // C++17 or lower:
 const double pi = std::acos(-1); // from <cmath>
 const T      pi = std::acos(T(-1));
-// note: all variables can be constexpr after C++26
+// note: all variables can be constexpr in C++26
 ```
 
 ## C
-```cpp
-const double pi = acos(-1); // from <math.h>
-const T      pi = acos((T) -1); // from <tgmath.h> (C11)
-// note: all variables can be constexpr after C23
-// warning: do not use M_PI, it is not portable
+```c
+const long double pil =
+  3.141592653589793238462643383279502884197169399375105820L;
+const double pi = (double) pil;
+const float pif = (float) pi;
+// note: all variables can be constexpr in C23
+// warning: do not use M_PI; it is not portable
 ```
 
 ## See Also on cppreference


### PR DESCRIPTION
Firstly, I feel like the `after` is too awkward; no one has phrased it that way in other resources afaik. cppreference always uses `since`, which makes sense for C23 since that standard is now feature-complete. However, it arguably doesn't make sense in C++26. I propose `in` as a neutral term.

Also, the recommendation for C isn't totally correct, because `constexpr` can only be used with GNU extensions there. Also, these variables cannot be global because static initialization is too limited.

We don't want to recommend macros, so the only sane alternative I see is to recommend manual constants.