### PR TITLE
Limit precision to binary128 format

### DIFF
--- a/wiki_articles/pi.md
+++ b/wiki_articles/pi.md
@@ -14,8 +14,7 @@ const T      pi = std::acos(T(-1));
 
 ## C
 ```c
-const long double pil =
-  3.141592653589793238462643383279502884197169399375105820L;
+const long double pil =3.1415926535897932384626433832795028L;
 const double pi = (double) pil;
 const float pif = (float) pi;
 // note: all variables can be constexpr in C23


### PR DESCRIPTION
As recommended in #28, this follow-up PR limits the precision to just enough digits for the *binary128* format.

This requires having no space between `=3`, otherwise it wouldn't fit on a single line. Overall, this PR makes the embed one line shorter.

![image](https://github.com/jeremy-rifkin/wheatley/assets/22040976/1ab292f6-5955-4aef-81f8-9ccaf5831718)
